### PR TITLE
[bug] Fix streaming missing one chunk error and install grpc-reflection in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -484,7 +484,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     else \
         BITSANDBYTES_VERSION="0.46.1"; \
     fi; \
-    uv pip install --system accelerate hf_transfer modelscope "bitsandbytes>=${BITSANDBYTES_VERSION}" 'timm>=1.0.17' 'runai-model-streamer[s3,gcs]>=0.15.0' 'grpcio>=1.75.1'
+    uv pip install --system accelerate hf_transfer modelscope "bitsandbytes>=${BITSANDBYTES_VERSION}" 'timm>=1.0.17' 'runai-model-streamer[s3,gcs]>=0.15.0' 'grpcio>=1.75.1' 'grpcio-reflection'
 
 ENV VLLM_USAGE_SOURCE production-docker-image
 

--- a/vllm/entrypoints/grpc_server.py
+++ b/vllm/entrypoints/grpc_server.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-# mypy: ignore-errors
 """
 vLLM gRPC Server
 
@@ -116,11 +115,12 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
                     return
 
                 # Convert vLLM output to protobuf
-                if request.stream and not output.finished:
-                    # Streaming chunk
+                # For streaming, always send chunks
+                if request.stream:
                     yield self._chunk_response(request_id, output)
-                elif output.finished:
-                    # Final response
+
+                # Send complete response when finished
+                if output.finished:
                     yield self._complete_response(request_id, output)
 
         except Exception as e:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

### Miss completion tokens in streaming

vLLM `OutputProcessor` generates output with `new_token_ids=[final_token]` and `finished=True` at last chunk.

In `grpc_server.py`, we currently check `if request.stream and not finished` to emit `chunk_response`, this causes the router to only receive `complete_response` when `finished=True` but not the new tokens along with finished. As a result, we always see one token less than `max_tokens`.

### Dockerfile

We need to install grpc-reflection in Dockerfile

## Test Plan
Send a request with `max_tokens=1`

## Test Result

before
<img width="1295" height="104" alt="Screenshot 2025-11-20 at 5 23 17 PM" src="https://github.com/user-attachments/assets/00ab1904-e4ad-479f-88a4-09d55cb6cfc2" />

after
<img width="1296" height="189" alt="Screenshot 2025-11-20 at 5 23 04 PM" src="https://github.com/user-attachments/assets/a7faaf44-e45d-49e7-833e-5b46e94e7cfa" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

