### PR TITLE
Pass usage_context in grpc_server and change warning log to debug

### DIFF
--- a/vllm/entrypoints/grpc_server.py
+++ b/vllm/entrypoints/grpc_server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# mypy: ignore-errors
 """
 vLLM gRPC Server
 
@@ -392,12 +393,14 @@ async def serve_grpc(args: argparse.Namespace):
     engine_args = AsyncEngineArgs.from_cli_args(args)
 
     # Build vLLM config
-    vllm_config = engine_args.create_engine_config()
+    vllm_config = engine_args.create_engine_config(
+        usage_context=UsageContext.OPENAI_API_SERVER
+    )
 
     # Create AsyncLLM
     async_llm = AsyncLLM.from_vllm_config(
         vllm_config=vllm_config,
-        usage_context=UsageContext.LLM_CLASS,
+        usage_context=UsageContext.OPENAI_API_SERVER,
         enable_log_requests=not args.disable_log_requests_server,
         disable_log_stats=args.disable_log_stats_server,
     )
@@ -417,11 +420,7 @@ async def serve_grpc(args: argparse.Namespace):
         options=[
             ("grpc.max_send_message_length", -1),
             ("grpc.max_receive_message_length", -1),
-            ("grpc.keepalive_time_ms", 10000),
-            ("grpc.keepalive_timeout_ms", 5000),
-            ("grpc.keepalive_permit_without_calls", True),
-            ("grpc.http2.max_pings_without_data", 0),
-        ]
+        ],
     )
 
     # Add servicer to server

--- a/vllm/grpc/grpc_request_manager.py
+++ b/vllm/grpc/grpc_request_manager.py
@@ -167,7 +167,10 @@ class GrpcRequestManager:
             collector = self.rid_to_collector.get(request_id)
 
             if collector is None:
-                logger.warning("Abort failed: request %s not found.", request_id)
+                logger.debug(
+                    "Abort: request %s not found (may have already completed).",
+                    request_id,
+                )
                 return False
 
             # Abort in AsyncLLM (this handles both engine_core and output_processor)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

### Max number of seqs mismatch

vLLM needs `UsageContext` to initiate a list of settings including `max_cudagraph_batch_size`, `max_num_seqs`, chunked_prefill `max_num_batched_tokens`, and etc.

Without it, there are fallbacks like `max_num_seqs=128` in scheduler.py. 

This kind of inconsistency causes the benchmark between grpc and http to have huge discrepancies.

This PR fixes the issue by passing `usage_context=OPENAI_API_SERVER` in `grpc_server.py`.

## Abort warning log

The abort warning log is spam. Changing it to debug.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

